### PR TITLE
updated to latest Ethsnarks branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ $(CLI): .build
 git-submodules:
 	git submodule update --init --recursive
 
+git-pull:
+	git pull --recurse-submodules
+	git submodule update --recursive --remote
+
 clean:
 	rm -rf .build
 

--- a/circuit/CMakeLists.txt
+++ b/circuit/CMakeLists.txt
@@ -3,8 +3,8 @@ project(ethsnarks-miximus)
 add_subdirectory(../ethsnarks ../.build/ethsnarks EXCLUDE_FROM_ALL)
 
 add_library(miximus SHARED miximus.cpp)
-target_link_libraries(miximus ethsnarks_common)
+target_link_libraries(miximus ethsnarks_common SHA3IUF)
 set_property(TARGET miximus PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_executable(miximus_cli miximus_cli.cpp)
-target_link_libraries(miximus_cli ethsnarks_common)
+target_link_libraries(miximus_cli ethsnarks_common SHA3IUF)

--- a/circuit/miximus.cpp
+++ b/circuit/miximus.cpp
@@ -23,9 +23,10 @@
 #include "stubs.hpp"
 #include "utils.hpp"
 
-#include "gadgets/longsightl.cpp"
-#include "gadgets/longsightl_constants.cpp"
+#include "gadgets/mimc.hpp"
 #include "gadgets/merkle_tree.cpp"
+
+#include <libsnark/gadgetlib1/gadgets/basic_gadgets.hpp>
 
 
 using libsnark::generate_r1cs_equals_const_constraint;
@@ -45,7 +46,7 @@ namespace ethsnarks {
 class mod_miximus : public GadgetT
 {
 public:
-    typedef LongsightL12p5_MP_gadget HashT;
+    typedef MiMC_hash_gadget HashT;
     const size_t tree_depth = MIXIMUS_TREE_DEPTH;
 
 

--- a/python/test/test_miximus.py
+++ b/python/test/test_miximus.py
@@ -1,6 +1,7 @@
 import unittest
 
-from ethsnarks.longsight import random_element, LongsightL12p5_MP
+from ethsnarks.field import FQ
+from ethsnarks.mimc import mimc_hash
 from ethsnarks.utils import native_lib_path
 from ethsnarks.merkletree import MerkleTree
 from miximus import Miximus
@@ -16,15 +17,13 @@ class TestMiximus(unittest.TestCase):
 		n_items = 2<<28
 		tree = MerkleTree(n_items)
 		for n in range(0, 2):
-			tree.append(random_element())
+			tree.append(int(FQ.random()))
 
-		exthash = random_element()
-		nullifier = random_element()
-		spend_preimage = random_element()
-		spend_hash_IV = 0
-		spend_hash = LongsightL12p5_MP([spend_preimage, nullifier], spend_hash_IV)
-		leaf_hash_IV = 0
-		leaf_hash = LongsightL12p5_MP([nullifier, spend_hash], leaf_hash_IV)
+		exthash = int(FQ.random())
+		nullifier = int(FQ.random())
+		spend_preimage = int(FQ.random())
+		spend_hash = mimc_hash([spend_preimage, nullifier])
+		leaf_hash = mimc_hash([nullifier, spend_hash])
 		leaf_idx = tree.append(leaf_hash)
 		self.assertEqual(leaf_idx, tree.index(leaf_hash))
 

--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+build
 package-lock.json

--- a/solidity/Makefile
+++ b/solidity/Makefile
@@ -1,3 +1,6 @@
+compile:
+	npm run compile
+
 node_modules:
 	npm install
 

--- a/solidity/contracts/Migrations.sol
+++ b/solidity/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 contract Migrations {
     address public owner;

--- a/solidity/contracts/Miximus.sol
+++ b/solidity/contracts/Miximus.sol
@@ -17,12 +17,12 @@
     along with Miximus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 import "../../ethsnarks/contracts/Verifier.sol";
 import "../../ethsnarks/contracts/SnarkUtils.sol";
 import "../../ethsnarks/contracts/MerkleTree.sol";
-import "../../ethsnarks/contracts/LongsightL.sol";
+import "../../ethsnarks/contracts/MiMC.sol";
 
 
 contract Miximus
@@ -58,17 +58,20 @@ contract Miximus
     function MakeLeafHash(uint256 spend_preimage, uint256 nullifier)
         public pure returns (uint256)
     {
-        uint256[10] memory round_constants;
-        LongsightL.ConstantsL12p5(round_constants);
+        uint256[] memory vals = new uint256[](2);
 
-        uint256 spend_hash = LongsightL.LongsightL12p5_MP([spend_preimage, nullifier], 0, round_constants);
+        vals[0] = spend_preimage;
+        vals[1] = nullifier;
+        uint256 spend_hash = MiMC.Hash(vals, 0);
 
-        return LongsightL.LongsightL12p5_MP([nullifier, spend_hash], 0, round_constants);
+        vals[0] = nullifier;
+        vals[1] = spend_hash;
+        return MiMC.Hash(vals, 0);
     }
 
 
     function GetPath(uint256 leaf)
-        public view returns (uint256[29] out_path, bool[29] out_addr)
+        public view returns (uint256[29] memory out_path, bool[29] memory out_addr)
     {
         return tree.GetProof(leaf);
     }
@@ -92,7 +95,7 @@ contract Miximus
     }
 
 
-    function VerifyProof( uint256 in_root, uint256 in_nullifier, uint256 in_exthash, uint256[8] proof )
+    function VerifyProof( uint256 in_root, uint256 in_nullifier, uint256 in_exthash, uint256[8] memory proof )
         public view returns (bool)
     {
         uint256[] memory snark_input = new uint256[](3);
@@ -111,7 +114,7 @@ contract Miximus
     function Withdraw(
         uint256 in_root,
         uint256 in_nullifier,
-        uint256[8] proof
+        uint256[8] memory proof
     )
         public
     {
@@ -128,5 +131,5 @@ contract Miximus
 
 
     function GetVerifyingKey ()
-        public view returns (uint256[14] out_vk, uint256[] out_gammaABC);
+        public view returns (uint256[14] memory out_vk, uint256[] memory out_gammaABC);
 }

--- a/solidity/contracts/TestableMiximus.sol
+++ b/solidity/contracts/TestableMiximus.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 import "./Miximus.sol";
 
@@ -12,7 +12,7 @@ contract TestableMiximus is Miximus
     uint256[14] m_vk;
     uint256[] m_gammaABC;
 
-    constructor( uint256[14] in_vk, uint256[] in_gammaABC )
+    constructor( uint256[14] memory in_vk, uint256[] memory in_gammaABC )
         public
     {
         m_vk = in_vk;
@@ -20,7 +20,7 @@ contract TestableMiximus is Miximus
     }
 
 
-    function TestVerify ( uint256[14] in_vk, uint256[] vk_gammaABC, uint256[8] in_proof, uint256[] proof_inputs )
+    function TestVerify ( uint256[14] memory in_vk, uint256[] memory vk_gammaABC, uint256[8] memory in_proof, uint256[] memory proof_inputs )
         public view returns (bool)
     {
         return Verifier.Verify(in_vk, vk_gammaABC, in_proof, proof_inputs);
@@ -28,7 +28,7 @@ contract TestableMiximus is Miximus
 
 
     function GetVerifyingKey ()
-        public view returns (uint256[14] out_vk, uint256[] out_gammaABC)
+        public view returns (uint256[14] memory out_vk, uint256[] memory out_gammaABC)
     {
         return (m_vk, m_gammaABC);
     }

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -1,6 +1,7 @@
 const Verifier = artifacts.require('Verifier.sol');
 const TestableMiximus = artifacts.require('TestableMiximus.sol');
-
+const MiMC = artifacts.require('MiMC.sol');
+const MerkleTree = artifacts.require('MerkleTree.sol');
 
 
 let list_flatten = (l) => {
@@ -23,8 +24,10 @@ let vk_to_flat = (vk) => {
 
 async function doDeploy( deployer, network )
 {
+    await deployer.deploy(MiMC);
 	await deployer.deploy(Verifier);
 	await deployer.link(Verifier, TestableMiximus);
+    await deployer.link(MiMC, TestableMiximus);
 
     var vk = require('../../.keys/miximus.vk.json');
     let [vk_flat, vk_flat_IC] = vk_to_flat(vk);

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -7,16 +7,17 @@
 	"author": "HarryR@noreply.users.gihub.com",
 	"license": "GPL-3.0+",
 	"dependencies": {
-		"solc": "^0.4.25",
-		"truffle": "^4.1.14"
+		"solc": "^0.5.2",
+		"truffle": "^5.0.1"
 	},
 	"devDependencies": {
-		"ganache-cli": "^6.1.8",
+		"ganache-cli": "^6.2.5",
 		"solidity-coverage": "^0.5.11",
-		"solhint": "^1.4.0",
+		"solhint": "^1.5.0",
 		"ffi": "node-ffi/node-ffi",
 		"ref": "^1.3.5",
-		"ref-array": "^1.2.0"
+		"ref-array": "^1.2.0",
+		"bn.js": "^4.11.8"
 	},
 	"scripts": {
 		"compile": "truffle compile",

--- a/solidity/test/TestMiximus.js
+++ b/solidity/test/TestMiximus.js
@@ -6,7 +6,7 @@ const fs = require("fs");
 const ffi = require("ffi");
 const ref = require("ref");
 const ArrayType = require("ref-array");
-const BigNumber = require("bignumber.js");
+const BN = require("bn.js");
 
 var StringArray = ArrayType(ref.types.CString);
 
@@ -76,14 +76,14 @@ contract("TestableMiximus", () => {
             let obj = await TestableMiximus.deployed();
 
             // Parameters for deposit
-            let spend_preimage = new BigNumber(crypto.randomBytes(30).toString("hex"), 16);
-            let nullifier = new BigNumber(crypto.randomBytes(30).toString("hex"), 16);
+            let spend_preimage = new BN(crypto.randomBytes(30).toString("hex"), 16);
+            let nullifier = new BN(crypto.randomBytes(30).toString("hex"), 16);
             let leaf_hash = await obj.MakeLeafHash.call(spend_preimage, nullifier);
 
 
             // Perform deposit
             let new_root_and_offset = await obj.Deposit.call(leaf_hash, {value: 1000000000000000000});
-            await obj.Deposit.sendTransaction([leaf_hash], {value: 1000000000000000000});
+            await obj.Deposit.sendTransaction(leaf_hash, {value: 1000000000000000000});
 
 
             // TODO: verify amount has been transferred


### PR DESCRIPTION
This moves from 'LongsightL' with a reduced number of rounds, to the `MiMC_hash_gadget` with the default number of rounds.

Support across Python, Solidity & C++