### PR TITLE
Frontrunning fix

### DIFF
--- a/circuit/miximus.hpp
+++ b/circuit/miximus.hpp
@@ -20,8 +20,6 @@ along with Miximus.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef MIXIMUS_HPP_
 #define MIXIMUS_HPP_
 
-#pragma once
-
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -33,7 +31,6 @@ const extern size_t MIXIMUS_TREE_DEPTH;
 char *miximus_prove(
     const char *pk_file,
     const char *in_root,
-    const char *in_nullifier,
     const char *in_exthash,
     const char *in_secret,
     const char *in_address,
@@ -44,10 +41,12 @@ int miximus_genkeys( const char *pk_file, const char *vk_file );
 
 bool miximus_verify( const char *vk_json, const char *proof_json );
 
+char* miximus_nullifier( const char *in_secret, const char *in_leaf_index );
+
 size_t miximus_tree_depth( void );
 
 #ifdef __cplusplus
-}
+} // extern "C" {
 #endif
 
 #endif

--- a/circuit/miximus.hpp
+++ b/circuit/miximus.hpp
@@ -1,3 +1,22 @@
+/*
+Copyright 2019 to the Miximus Authors
+
+This file is part of Miximus.
+
+Miximus is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Miximus is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Miximus.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef MIXIMUS_HPP_
 #define MIXIMUS_HPP_
 
@@ -16,7 +35,7 @@ char *miximus_prove(
     const char *in_root,
     const char *in_nullifier,
     const char *in_exthash,
-    const char *in_spend_preimage,
+    const char *in_secret,
     const char *in_address,
     const char **in_path
 );

--- a/circuit/miximus_cli.cpp
+++ b/circuit/miximus_cli.cpp
@@ -1,5 +1,21 @@
-// Copyright (c) 2018 HarryR
-// License: GPL-3.0+
+/*
+Copyright 2019 to the Miximus Authors
+
+This file is part of Miximus.
+
+Miximus is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Miximus is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Miximus.  If not, see <https://www.gnu.org/licenses/>.
+*/
 
 #include <cstring>
 #include <iostream> // cerr
@@ -24,14 +40,14 @@ static int main_prove( int argc, char **argv )
 {
     if( argc < (9 + (int)MIXIMUS_TREE_DEPTH) )
     {
-        cerr << "Usage: " << argv[0] << " prove <pk.raw> <proof.json> <public:root> <public:nullifier> <public:exthash> <secret:preimage> <secret:merkle-address> <secret:merkle-path ...>" << endl;
+        cerr << "Usage: " << argv[0] << " prove <pk.raw> <proof.json> <public:root> <public:nullifier> <public:exthash> <secret:secret> <secret:merkle-address> <secret:merkle-path ...>" << endl;
         cerr << "Args: " << endl;
         cerr << "\t<pk.raw>         Path to proving key" << endl;
         cerr << "\t<proof.json>     Write proof to this file" << endl;
         cerr << "\t<root>           Merkle tree root" << endl;
         cerr << "\t<nullifier>      Nullifier" << endl;
         cerr << "\t<exthash>        Hash of external variables" << endl;
-        cerr << "\t<preimage>       Spend preimage" << endl;
+        cerr << "\t<secret>         Spend secret" << endl;
         cerr << "\t<merkle-address> 0 and 1 bits for tree path" << endl;
         cerr << "\t<merkle-path...> items for merkle tree path" << endl;
         return 1;
@@ -42,7 +58,7 @@ static int main_prove( int argc, char **argv )
     auto arg_root = argv[4];
     auto arg_nullifier = argv[5];
     auto arg_exthash = argv[6];
-    auto arg_preimage = argv[7];
+    auto arg_secret = argv[7];
     auto arg_address = argv[8];
     
     const char *arg_path[MIXIMUS_TREE_DEPTH];
@@ -50,7 +66,7 @@ static int main_prove( int argc, char **argv )
         arg_path[i] = argv[9 + i];
     }
 
-    auto json = miximus_prove(pk_filename, arg_root, arg_nullifier, arg_exthash, arg_preimage, arg_address, arg_path);
+    auto json = miximus_prove(pk_filename, arg_root, arg_nullifier, arg_exthash, arg_secret, arg_address, arg_path);
 
     ofstream fh;
     fh.open(proof_filename, std::ios::binary);
@@ -70,19 +86,21 @@ int main( int argc, char **argv )
         return 1;
     }
 
-    if( 0 == ::strcmp(argv[1], "prove") )
+    const std::string arg_cmd(argv[1]);
+
+    if( arg_cmd == "prove" )
     {
         return main_prove(argc, argv);
     }
-    else if( 0 == ::strcmp(argv[1], "genkeys") )
+    else if( arg_cmd == "genkeys" )
     {
         return stub_main_genkeys<mod_miximus>(argv[0], argc-1, &argv[1]);
     }
-    else if( 0 == ::strcmp(argv[1], "verify") )
+    else if( arg_cmd == "verify" )
     {
         return stub_main_verify(argv[0], argc-1, (const char **)&argv[1]);
     }
 
-    cerr << "Error: unknown sub-command " << argv[1] << endl;
+    cerr << "Error: unknown sub-command " << arg_cmd << endl;
     return 2;
 }

--- a/circuit/miximus_cli.cpp
+++ b/circuit/miximus_cli.cpp
@@ -45,7 +45,6 @@ static int main_prove( int argc, char **argv )
         cerr << "\t<pk.raw>         Path to proving key" << endl;
         cerr << "\t<proof.json>     Write proof to this file" << endl;
         cerr << "\t<root>           Merkle tree root" << endl;
-        cerr << "\t<nullifier>      Nullifier" << endl;
         cerr << "\t<exthash>        Hash of external variables" << endl;
         cerr << "\t<secret>         Spend secret" << endl;
         cerr << "\t<merkle-address> 0 and 1 bits for tree path" << endl;
@@ -56,17 +55,16 @@ static int main_prove( int argc, char **argv )
     auto pk_filename = argv[2];
     auto proof_filename = argv[3];
     auto arg_root = argv[4];
-    auto arg_nullifier = argv[5];
-    auto arg_exthash = argv[6];
-    auto arg_secret = argv[7];
-    auto arg_address = argv[8];
+    auto arg_exthash = argv[5];
+    auto arg_secret = argv[6];
+    auto arg_address = argv[7];
     
     const char *arg_path[MIXIMUS_TREE_DEPTH];
     for( size_t i = 0; i < MIXIMUS_TREE_DEPTH; i++ ) {
         arg_path[i] = argv[9 + i];
     }
 
-    auto json = miximus_prove(pk_filename, arg_root, arg_nullifier, arg_exthash, arg_secret, arg_address, arg_path);
+    auto json = miximus_prove(pk_filename, arg_root, arg_exthash, arg_secret, arg_address, arg_path);
 
     ofstream fh;
     fh.open(proof_filename, std::ios::binary);

--- a/python/miximus.py
+++ b/python/miximus.py
@@ -1,3 +1,22 @@
+"""
+Copyright 2019 to the Miximus Authors
+
+This file is part of Miximus.
+
+Miximus is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Miximus is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Miximus.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
 __all__ = ('Miximus',)
 
 import os

--- a/python/miximus.py
+++ b/python/miximus.py
@@ -50,19 +50,31 @@ class Miximus(object):
         lib_tree_depth.restype = ctypes.c_size_t
         self.tree_depth = lib_tree_depth()
         assert self.tree_depth > 0
-        assert self.tree_depth < 32
+        assert self.tree_depth <= 32
 
         lib_prove = lib.miximus_prove
-        lib_prove.argtypes = ([ctypes.c_char_p] * 6) + [(ctypes.c_char_p * self.tree_depth)]
+        lib_prove.argtypes = ([ctypes.c_char_p] * 5) + [(ctypes.c_char_p * self.tree_depth)]
         lib_prove.restype = ctypes.c_char_p
         self._prove = lib_prove
 
         lib_verify = lib.miximus_verify
-        lib_verify.argtypes = [ctypes.c_char_p, ctypes.c_char_p] 
+        lib_verify.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
         lib_verify.restype = ctypes.c_bool
         self._verify = lib_verify
 
-    def prove(self, root, nullifier, spend_preimage, exthash, address_bits, path, pk_file=None):
+        lib_nullifier = lib.miximus_nullifier
+        lib_nullifier.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+        lib_nullifier.restype = ctypes.c_char_p
+        self._nullifier = lib_nullifier
+
+    def nullifier(self, secret, leaf_index):
+        assert isinstance(secret, int)
+        assert isinstance(leaf_index, int)
+        secret = ctypes.c_char_p(str(secret).encode('ascii'))
+        leaf_index = ctypes.c_char_p(str(leaf_index).encode('ascii'))
+        return int(self._nullifier(secret, leaf_index))
+
+    def prove(self, root, spend_preimage, exthash, address_bits, path, pk_file=None):
         assert isinstance(path, (list, tuple))
         assert len(path) == self.tree_depth
         if isinstance(address_bits, (tuple, list)):
@@ -70,7 +82,6 @@ class Miximus(object):
         assert re.match(r'^[01]+$', address_bits)
         assert len(address_bits) == self.tree_depth
         assert isinstance(root, int)
-        assert isinstance(nullifier, int)
         assert isinstance(spend_preimage, int)
         assert isinstance(exthash, int)
         # TODO: require root, nullifier, spend_preimage and exthash are ints within curve order range
@@ -82,7 +93,6 @@ class Miximus(object):
 
         # Public parameters
         root = ctypes.c_char_p(str(root).encode('ascii'))
-        nullifier = ctypes.c_char_p(str(nullifier).encode('ascii'))
         exthash = ctypes.c_char_p(str(exthash).encode('ascii'))
     
         # Private parameters
@@ -94,7 +104,7 @@ class Miximus(object):
 
         pk_file_cstr = ctypes.c_char_p(pk_file.encode('ascii'))
 
-        data = self._prove(pk_file_cstr, root, nullifier, exthash, spend_preimage, address_bits, path_carr)
+        data = self._prove(pk_file_cstr, root, exthash, spend_preimage, address_bits, path_carr)
         if data is None:
             raise RuntimeError("Could not prove!")
         return Proof.from_json(data)

--- a/python/test/test_miximus.py
+++ b/python/test/test_miximus.py
@@ -20,12 +20,12 @@ class TestMiximus(unittest.TestCase):
 			tree.append(int(FQ.random()))
 
 		exthash = int(FQ.random())
-		nullifier = int(FQ.random())
-		spend_preimage = int(FQ.random())
-		spend_hash = mimc_hash([spend_preimage, nullifier])
-		leaf_hash = mimc_hash([nullifier, spend_hash])
+		secret = int(FQ.random())
+		leaf_hash = mimc_hash([secret])
 		leaf_idx = tree.append(leaf_hash)
 		self.assertEqual(leaf_idx, tree.index(leaf_hash))
+
+		nullifier = mimc_hash([leaf_idx, secret])
 
 		# Verify it exists in true
 		leaf_proof = tree.proof(leaf_idx)
@@ -36,8 +36,7 @@ class TestMiximus(unittest.TestCase):
 		tree_depth = wrapper.tree_depth
 		snark_proof = wrapper.prove(
 			tree.root,
-			nullifier,
-			spend_preimage,
+			secret,
 			exthash,
 			leaf_proof.address,
 			leaf_proof.path)

--- a/solidity/.solhint.json
+++ b/solidity/.solhint.json
@@ -1,0 +1,17 @@
+{
+	"extends": "default",
+	"rules": {
+		"indent": false,
+		"var-name-mixedcase": false,
+		"func-name-mixedcase": false,
+		"func-param-name-mixedcase": false,
+		"not-rely-on-time": false,
+		"bracket-align": false,
+		"expression-indent": false,
+		"max-line-length": false,
+		"two-lines-top-level-separator": false,
+		"separate-by-one-line-in-contract": false,
+		"function-max-lines": false,
+		"compiler-fixed": false
+	}
+}

--- a/solidity/Makefile
+++ b/solidity/Makefile
@@ -1,3 +1,5 @@
+all: lint compile test
+
 compile:
 	npm run compile
 
@@ -7,3 +9,6 @@ node_modules:
 .PHONY: test
 test: node_modules
 	npm run test
+
+lint:
+	npm run lint

--- a/solidity/contracts/Miximus.sol
+++ b/solidity/contracts/Miximus.sol
@@ -1,26 +1,25 @@
 /*    
-    copyright 2018 to the Miximus Authors
+Copyright 2019 to the Miximus Authors
 
-    This file is part of Miximus.
+This file is part of Miximus.
 
-    Miximus is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Miximus is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    Miximus is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+Miximus is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with Miximus.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with Miximus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 pragma solidity ^0.5.0;
 
 import "../../ethsnarks/contracts/Verifier.sol";
-import "../../ethsnarks/contracts/SnarkUtils.sol";
 import "../../ethsnarks/contracts/MerkleTree.sol";
 import "../../ethsnarks/contracts/MiMC.sol";
 
@@ -55,18 +54,19 @@ contract Miximus
     }
 
 
-    function MakeLeafHash(uint256 spend_preimage, uint256 nullifier)
+    function MakeLeafHash(uint256 secret, uint256 nullifier)
         public pure returns (uint256)
     {
+        // TODO: only need to hash the secret
         uint256[] memory vals = new uint256[](2);
 
-        vals[0] = spend_preimage;
+        vals[0] = secret;
         vals[1] = nullifier;
-        uint256 spend_hash = MiMC.Hash(vals, 0);
+        uint256 spend_hash = MiMC.Hash(vals);
 
         vals[0] = nullifier;
         vals[1] = spend_hash;
-        return MiMC.Hash(vals, 0);
+        return MiMC.Hash(vals);
     }
 
 
@@ -95,13 +95,27 @@ contract Miximus
     }
 
 
+    /**
+    * Condense multiple public inputs down to a single one to be provided to the zkSNARK circuit
+    */
+    function HashPublicInputs( uint256 in_root, uint256 in_nullifier, uint256 in_exthash )
+        public pure returns (uint256)
+    {
+        uint256[] memory inputs_to_hash = new uint256[](3);
+
+        inputs_to_hash[0] = in_root;
+        inputs_to_hash[1] = in_nullifier;
+        inputs_to_hash[2] = in_exthash;
+
+        return MiMC.Hash(inputs_to_hash);
+    }
+
+
     function VerifyProof( uint256 in_root, uint256 in_nullifier, uint256 in_exthash, uint256[8] memory proof )
         public view returns (bool)
     {
-        uint256[] memory snark_input = new uint256[](3);
-        snark_input[0] = in_root;
-        snark_input[1] = in_nullifier;
-        snark_input[2] = in_exthash;
+        uint256[] memory snark_input = new uint256[](1);
+        snark_input[0] = HashPublicInputs(in_root, in_nullifier, in_exthash);
 
         uint256[14] memory vk;
         uint256[] memory vk_gammaABC;

--- a/solidity/contracts/Miximus.sol
+++ b/solidity/contracts/Miximus.sol
@@ -78,18 +78,11 @@ contract Miximus
     }
 
 
-    function MakeLeafHash(uint256 secret, uint256 nullifier)
+    function MakeLeafHash(uint256 secret)
         public pure returns (uint256)
     {
-        // TODO: only need to hash the secret
-        uint256[] memory vals = new uint256[](2);
-
+        uint256[] memory vals = new uint256[](1);
         vals[0] = secret;
-        vals[1] = nullifier;
-        uint256 spend_hash = MiMC.Hash(vals);
-
-        vals[0] = nullifier;
-        vals[1] = spend_hash;
         return MiMC.Hash(vals);
     }
 

--- a/solidity/contracts/Miximus.sol
+++ b/solidity/contracts/Miximus.sol
@@ -28,13 +28,33 @@ contract Miximus
 {
     using MerkleTree for MerkleTree.Data;
 
+    // Denomination of each token
     uint constant public AMOUNT = 1 ether;
 
+    // Stores the nullifiers for every spent coin (preventing double spend)
     mapping (uint256 => bool) public nullifiers;
+
+    // Stores all of the valid merkle tree roots
+    mapping (uint256 => bool) public roots;
 
     MerkleTree.Data internal tree;
 
 
+    /**
+    * Used to be notified that a specific leaf has been deposited
+    */
+    event OnDeposit( uint256 leaf_hash, uint256 leaf_index );
+
+
+    /**
+    * Used to quickly lookup if a coin has been spent
+    */
+    event OnWithdraw( uint256 nullifier );
+
+
+    /**
+    * What is the current root for the merkle tree
+    */
     function GetRoot()
         public view returns (uint256)
     {
@@ -48,9 +68,13 @@ contract Miximus
     function Deposit(uint256 leaf)
         public payable returns (uint256 new_root, uint256 new_offset)
     {
-        require( msg.value == AMOUNT );
+        require( msg.value == AMOUNT, "Must deposit exact amount" );
 
-        return tree.Insert(leaf);
+        (new_root, new_offset) = tree.Insert(leaf);
+
+        roots[new_root] = true;
+
+        emit OnDeposit(leaf, new_offset);
     }
 
 
@@ -70,10 +94,14 @@ contract Miximus
     }
 
 
-    function GetPath(uint256 leaf)
+    /**
+    * Retrieve the merkle tree path for a specific leaf
+    * TODO: remove `out_addr` - it's unnecessary, given we know the leaf index
+    */
+    function GetPath(uint256 in_leaf_index)
         public view returns (uint256[29] memory out_path, bool[29] memory out_addr)
     {
-        return tree.GetProof(leaf);
+        return tree.GetProof(in_leaf_index);
     }
 
 
@@ -98,7 +126,11 @@ contract Miximus
     /**
     * Condense multiple public inputs down to a single one to be provided to the zkSNARK circuit
     */
-    function HashPublicInputs( uint256 in_root, uint256 in_nullifier, uint256 in_exthash )
+    function HashPublicInputs(
+        uint256 in_root,
+        uint256 in_nullifier,
+        uint256 in_exthash
+    )
         public pure returns (uint256)
     {
         uint256[] memory inputs_to_hash = new uint256[](3);
@@ -111,39 +143,62 @@ contract Miximus
     }
 
 
-    function VerifyProof( uint256 in_root, uint256 in_nullifier, uint256 in_exthash, uint256[8] memory proof )
+    function VerifyProof(
+        uint256 in_root,
+        uint256 in_nullifier,
+        uint256 in_exthash,
+        uint256[8] memory proof
+    )
         public view returns (bool)
     {
+        // Public inputs for the zkSNARK circuit are hashed into a single input
         uint256[] memory snark_input = new uint256[](1);
         snark_input[0] = HashPublicInputs(in_root, in_nullifier, in_exthash);
 
+        // Retrieve verifying key
         uint256[14] memory vk;
         uint256[] memory vk_gammaABC;
         (vk, vk_gammaABC) = GetVerifyingKey();
 
+        // Validate the proof
         return Verifier.Verify( vk, vk_gammaABC, proof, snark_input );
     }
 
 
+    /**
+    * Withdraw a token from the mixer
+    */
     function Withdraw(
         uint256 in_root,
         uint256 in_nullifier,
-        uint256[8] memory proof
+        uint256[8] memory in_proof
     )
         public
     {
-        require( false == nullifiers[in_nullifier] );
+        require( false == nullifiers[in_nullifier], "Cannot double-spend" );
 
-        bool is_valid = VerifyProof(in_root, in_nullifier, GetExtHash(), proof);
+        require( true == roots[in_root], "Must specify known merkle tree root" );
 
-        require( is_valid );
+        bool is_valid = VerifyProof(in_root, in_nullifier, GetExtHash(), in_proof);
+
+        require( is_valid, "Proof invalid!" );
 
         nullifiers[in_nullifier] = true;
 
         msg.sender.transfer(AMOUNT);
+
+        emit OnWithdraw(in_nullifier);
     }
 
 
+    /**
+    * Contracts which inherit this one must implement a mechanism to retrieve the verification key
+    *
+    * It is up to the implementor to figure out how to do this, but it could be hard-coded or
+    * passed in via the constructor.
+    *
+    * See `TestableMiximus` as an example, which loads the verification key from storage.
+    */
     function GetVerifyingKey ()
         public view returns (uint256[14] memory out_vk, uint256[] memory out_gammaABC);
 }

--- a/solidity/contracts/TestableMiximus.sol
+++ b/solidity/contracts/TestableMiximus.sol
@@ -9,8 +9,8 @@ import "./Miximus.sol";
 
 contract TestableMiximus is Miximus
 {
-    uint256[14] m_vk;
-    uint256[] m_gammaABC;
+    uint256[14] private m_vk;
+    uint256[] private m_gammaABC;
 
     constructor( uint256[14] memory in_vk, uint256[] memory in_gammaABC )
         public

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -7,23 +7,23 @@
 	"author": "HarryR@noreply.users.gihub.com",
 	"license": "GPL-3.0+",
 	"dependencies": {
-		"solc": "^0.5.2",
-		"truffle": "^5.0.1"
+		"solc": "^0.5.3",
+		"truffle": "^5.0.2"
 	},
 	"devDependencies": {
+		"bn.js": "^4.11.8",
+		"ffi": "github:node-ffi/node-ffi",
 		"ganache-cli": "^6.2.5",
-		"solidity-coverage": "^0.5.11",
-		"solhint": "^1.5.0",
-		"ffi": "node-ffi/node-ffi",
 		"ref": "^1.3.5",
 		"ref-array": "^1.2.0",
-		"bn.js": "^4.11.8"
+		"solhint": "^1.5.0",
+		"solidity-coverage": "^0.5.11"
 	},
 	"scripts": {
 		"compile": "truffle compile",
 		"test": "truffle test",
 		"testrpc": "ganache-cli",
-		"coverage": "truffle-coverage",
+		"coverage": "solidity-coverage",
 		"lint": "solhint contracts/**/*.sol"
 	}
 }

--- a/solidity/test/TestMiximus.js
+++ b/solidity/test/TestMiximus.js
@@ -99,7 +99,7 @@ contract("TestableMiximus", () => {
             let proof_root = await obj.GetRoot.call();
             proof_root = new_root_and_offset[0];
             let proof_exthash = await obj.GetExtHash.call();
-
+            let proof_pub_hash = await obj.HashPublicInputs.call(proof_root, nullifier, proof_exthash);
 
             // Run prover to generate proof
             let args = [
@@ -116,10 +116,8 @@ contract("TestableMiximus", () => {
             let proof = JSON.parse(proof_json);
 
 
-            // Ensure proof inputs match ours
-            assert.strictEqual("0x" + proof_root.toString(16), proof.input[0]);
-            assert.strictEqual("0x" + nullifier.toString(16), proof.input[1]);
-            assert.strictEqual("0x" + proof_exthash.toString(16), proof.input[2]);
+            // Ensure proof inputs match what is expected
+            assert.strictEqual("0x" + proof_pub_hash.toString(16), proof.input[0]);
 
 
             // Re-verify proof using native library
@@ -137,9 +135,7 @@ contract("TestableMiximus", () => {
                 vk_flat_IC,             // gammaABC[]
                 proof_to_flat(proof),   // A B C
                 [  
-                    proof.input[0],
-                    proof.input[1],
-                    proof.input[2]
+                    proof.input[0]
                 ]
             ];
             let test_verify_result = await obj.TestVerify(...test_verify_args);
@@ -148,9 +144,9 @@ contract("TestableMiximus", () => {
 
             // Verify whether or not our proof would be valid
             let proof_valid = await obj.VerifyProof.call(
-                proof.input[0],
-                proof.input[1],
-                proof.input[2],
+                proof_root,
+                nullifier,
+                proof_exthash,
                 proof_to_flat(proof));
             assert.strictEqual(proof_valid, true);
 


### PR DESCRIPTION
Fixes: #2 

This modifies how the nullifier is calculated to prevent the front-running / DoS described in #2

It also simplifies the circuit:

```python
def circuit(secret, path_var, address_bits, nullifier, root, external_hash, pub_hash):
   assert H(root, nullifier, external_hash) == pub_hash
   leaf_hash = H(secret) # Prove we know the secret for the leaf
   assert root == merkle_authenticate(path_var, address_bits, leaf_hash) # Prove that leaf exists within the tree
   assert H(address_bits, secret) == nullifier
```

This depends on https://github.com/HarryR/ethsnarks/pull/109